### PR TITLE
Truncate long step names more

### DIFF
--- a/buildbot_travis/steps/create_steps.py
+++ b/buildbot_travis/steps/create_steps.py
@@ -210,7 +210,7 @@ class TravisSetupSteps(ConfigurableStep):
     name = "setup-steps"
     haltOnFailure = True
     flunkOnFailure = True
-    MAX_NAME_LENGTH = 50
+    MAX_NAME_LENGTH = 47
 
     def addSetupVirtualEnv(self, python):
         step = SetupVirtualEnv(python)


### PR DESCRIPTION
When the step name is too long then it gets truncated. However, when the ellipses are appended the name is at the maximum length. If multiple steps have the same name after the truncation, then the subsequent mangling to add a "_N" pushes the step name over the maximum length. Remove three more characters from the end to give room for "_NN".
