### PR TITLE
Specify options before docker image name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ QuickStart With Docker
 
 ::
 
-    docker run buildbot/buildbot-travis -p 8010:8010 -p 9989:9989
+    docker run -p 8010:8010 -p 9989:9989 buildbot/buildbot-travis
 
 
 QuickStart With Hyper


### PR DESCRIPTION
Otherwise you get `docker: Error response from daemon: oci runtime error: exec: "-p": executable file not found in $PATH.` when you try to run that command.