### PR TITLE
Add support for BitbucketAuth

### DIFF
--- a/buildbot_travis/configurator.py
+++ b/buildbot_travis/configurator.py
@@ -179,6 +179,11 @@ class TravisConfigurator(object):
             return None
         return util.GitHubAuth(authcfg["clientid"], authcfg["clientsecret"])
 
+    def createAuthConfigBitbucket(self, authcfg):
+        if not self.configAssertContains(authcfg, ['clientid', 'clientsecret']):
+            return None
+        return util.BitbucketAuth(authcfg["clientid"], authcfg["clientsecret"])
+
     def createAuthConfigGoogle(self, authcfg):
         if not self.configAssertContains(authcfg, ['clientid', 'clientsecret']):
             return None

--- a/buildbot_travis/tests/test_configurator.py
+++ b/buildbot_travis/tests/test_configurator.py
@@ -52,6 +52,17 @@ class TravisConfiguratorTestCase(unittest.TestCase, config.ConfigErrorsMixin):
         self.c.createAuthConfig()
         self.assertIsInstance(self.c.config['www']['auth'], util.GitHubAuth)
 
+    def test_auth_bitbucket(self):
+        self.c.cfgdict = {
+            'auth': {
+                'type': 'Bitbucket',
+                'clientid': 'foo',
+                'clientsecret': 'bar'
+            }
+        }
+        self.c.createAuthConfig()
+        self.assertIsInstance(self.c.config['www']['auth'], util.BitbucketAuth)
+
     def test_auth_google(self):
         self.c.cfgdict = {
             'auth': {

--- a/buildbot_travis/ui/src/app/configEditors/auth.tpl.jade
+++ b/buildbot_travis/ui/src/app/configEditors/auth.tpl.jade
@@ -9,6 +9,7 @@ config-page
                         option(value="AdminPassword") Admin Password
                         option(value="GitHub") GitHub OAuth2
                         option(value="GitLab") GitLab OAuth2
+                        option(value="Bitbucket") Bitbucket OAuth2
                         option(value="Google") Google OAuth2
                         option(value="Custom") Custom Authentication Python Code
 

--- a/buildbot_travis/ui/src/app/configEditors/bbtravis_config.controller.coffee
+++ b/buildbot_travis/ui/src/app/configEditors/bbtravis_config.controller.coffee
@@ -166,10 +166,11 @@ class AuthConfig extends Controller
             if type == "Custom" and not self.$scope.auth.customauthzcode
                 self.$scope.auth.customauthzcode = DEFAULT_CUSTOM_AUTHZCODE
         @$scope.isOAuth = ->
-            return self.$scope.auth.type in [ "Google", "GitLab", "GitHub"]
+            return self.$scope.auth.type in [ "Google", "GitLab", "GitHub", "Bitbucket"]
         @$scope.getOAuthDoc = (type) ->
             return {
                 Google: "https://developers.google.com/accounts/docs/OAuth2"
                 GitLab: "http://docs.gitlab.com/ce/api/oauth2.html"
                 GitHub: "https://developer.github.com/v3/oauth/"
+                Bitbucket: "https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html"
             }[type]


### PR DESCRIPTION
Support for BitbucketAuth introduced in buildbot commit [3c1b2ca4](https://github.com/buildbot/buildbot/commit/3c1b2ca46886c90591d153f12865ed9116c021a8)

Should there be a mechanism to handle prior versions of buildbot without BitbucketAuth? 