### PR TITLE
Fix interpolation for docker and ui configurator tooltip

### DIFF
--- a/buildbot_travis/configurator.py
+++ b/buildbot_travis/configurator.py
@@ -259,7 +259,8 @@ class TravisConfigurator(object):
 
     def createWorkerConfigDockerWorker(self, config, name):
         return worker.DockerLatentWorker(name, str(uuid.uuid4()),
-                                         docker_host=config['docker_host'], image=config['image'],
+                                         docker_host=config['docker_host'], 
+                                         image=util.Interpolate(config['image']),
                                          followStartupLogs=True)
 
     def createWorkerConfigHyperWorker(self, config, name):

--- a/buildbot_travis/ui/src/app/configEditors/workers_config.tpl.jade
+++ b/buildbot_travis/ui/src/app/configEditors/workers_config.tpl.jade
@@ -53,7 +53,7 @@ config-page
                     .form-group
                         label.col-sm-2.control-label image name:
                         .col-sm-10
-                            input.form-control(type="text", ng-model="worker.image", placeholder = "buildbot/worker-%{prop:language}")
+                            input.form-control(type="text", ng-model="worker.image", placeholder = "buildbot/worker-%(prop:language)s")
                     .alert.alert-info
                         b Note:&nbsp;
                         | image name is interpolated with buildrequest properties


### PR DESCRIPTION
Interpolation for docker image names didn't work. Also UI tip in image input was wrong.