### PR TITLE
Add support for configuring docker volumes

### DIFF
--- a/buildbot_travis/configurator.py
+++ b/buildbot_travis/configurator.py
@@ -265,8 +265,10 @@ class TravisConfigurator(object):
         return worker.LocalWorker(name)
 
     def createWorkerConfigDockerWorker(self, config, name):
+        volumes = [v.strip() for v in config.get('volumes', '').split(',')]
         return worker.DockerLatentWorker(name, str(uuid.uuid4()),
                                          docker_host=config['docker_host'],
+                                         volumes=volumes,
                                          image=util.Interpolate(config['image']),
                                          followStartupLogs=True)
 

--- a/buildbot_travis/tests/test_configurator.py
+++ b/buildbot_travis/tests/test_configurator.py
@@ -224,6 +224,7 @@ class TravisConfiguratorTestCase(unittest.TestCase, config.ConfigErrorsMixin):
                 'name': 'foo',
                 'number': 10,
                 'docker_host': 'tcp://foo:2193',
+                'volumes': '/foo:/foo, /bar:/bar',
                 'image': 'slave'
             }]
         }
@@ -231,3 +232,6 @@ class TravisConfiguratorTestCase(unittest.TestCase, config.ConfigErrorsMixin):
         self.assertIsInstance(self.c.config['workers'][0], worker.DockerLatentWorker)
         self.assertEqual(self.c.config['workers'][0].name, 'foo_1')
         self.assertEqual(len(self.c.config['workers']), 10)
+        self.assertEqual(
+            self.c.config['workers'][0].getConfigDict()['kwargs']['volumes'],
+            ['/foo:/foo', '/bar:/bar'])

--- a/buildbot_travis/ui/src/app/configEditors/workers_config.tpl.jade
+++ b/buildbot_travis/ui/src/app/configEditors/workers_config.tpl.jade
@@ -63,6 +63,16 @@ config-page
                     .col-sm-10
                         input.form-control(type="text", ng-model="worker.docker_host", placeholder = "tcp://dockerhost:2375")
 
+                div(ng-if="worker.type=='DockerWorker'")
+                    .form-group
+                        label.col-sm-2.control-label Volumes:
+                        .col-sm-10
+                            input.form-control(type="text", ng-model="worker.volumes", placeholder = "/var/run/docker.sock:/var/run/docker.sock")
+
+                    .alert.alert-info
+                        b Note:&nbsp;
+                        | multiple volumes can be separated by a comma
+
     .row
         .col-sm-12
             .input-group.filelist


### PR DESCRIPTION
Buildbot provides the ability to use volumes with the docker latent worker. It would be useful to expose this functionality so that they can be configured via the web interface, instead of needing to hard-code the docker workers in the `master.cfg` file.