### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,7 @@ QuickStart
 First you need to make sure you have the proper python 2.7 environment. On ubuntu 16.04, that would mean::
 
     sudo apt-get install build-essential python-dev libffi-dev libssl-dev python-pip
+    pip install virtualenv
 
 Then you create a virtualenv and install buildbot_travis via pip::
 


### PR DESCRIPTION
`virtualenv` is not installed by default with the packages listed, and if you try to `apt-get install virtualenv` you will get a Pyhton _3_ version of it instead... So this seems like the easiest way to ensure it's in place.