### PR TITLE
Fixes

### DIFF
--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     buildbot:
     # switch between local build and dockerhub image
     #    build: ../
-        image: "buildbot/buildbot_travis"
+        image: "buildbot/buildbot-travis"
         env_file: db.env
         ports:
             - "8010:8010"

--- a/example/start_buildbot.sh
+++ b/example/start_buildbot.sh
@@ -3,7 +3,7 @@ B=`pwd`
 if [ ! -f $B/buildbot.tac ]
 then
     bbtravis create-master $B
-    cp /usr/src/buildbot/contrib/docker/master/buildbot.tac $B
+    cp /usr/src/buildbot_travis/example/buildbot.tac $B
 fi
 # wait for pg to start by trying to upgrade the master
 until buildbot upgrade-master $B


### PR DESCRIPTION
This PR fixes two minor naming issues:
* the docker image named in the `docker-compose` config is mis-spelled.
* the filepath to `buildbot.tac` in the `start_buildbot.sh` script doesn't correspond to the name in the Dockerfile.